### PR TITLE
Set forceBasemapSelection to false by default

### DIFF
--- a/src/main/js/bundles/dn_basemapslider/manifest.json
+++ b/src/main/js/bundles/dn_basemapslider/manifest.json
@@ -57,7 +57,7 @@
                 "autoplayEnabled": false,
                 "autoplayInterval": 500,
                 "autoplayOpacityIncrement": 0.5,
-                "forceBasemapSelection": true,
+                "forceBasemapSelection": false,
                 "widgetDisplayMode": "arrow"
             }
         },


### PR DESCRIPTION
If forceBasemapSelection is set to true by default and not overwritten by the app config, the basemap can not be changed anymore.